### PR TITLE
Update README with Chez command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
     $ ypsilon ~/scheme/agave/demos/flexi-line.scm
 
+## Run a demo in Chez
+
+    $ chez --program ~/scheme/agave/demos/flexi-line.scm
+
 ## Run a demo in Ikarus
 
     $ ikarus --r6rs-script ~/scheme/agave/demos/flexi-line.scm


### PR DESCRIPTION
I got the demos to run in Chez by installing `agave` from the Akku package manager (which now lists `chez-gl` as a dependency). Chez needs the `--program` argument or else macros will fail [due to this problem](https://stackoverflow.com/questions/54173992/chez-scheme-macro-import-at-top-level).